### PR TITLE
Change build command to work with npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ async function run() {
 
     const gatsbyArgs = core.getInput("gatsby-args")
     console.log("Ready to build your Gatsby site!")
-    console.log(`Building with: ${pkgManager} run gatsby build ${gatsbyArgs}`)
-    await exec.exec(`${pkgManager} run gatsby build`, [gatsbyArgs])
+    console.log(`Building with: ${pkgManager} run build ${gatsbyArgs}`)
+    await exec.exec(`${pkgManager} run build`, [gatsbyArgs])
     console.log("Finished buidling your site.")
 
     const cnameExists = await ioUtil.exists("./CNAME")

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function run() {
     console.log("Ready to build your Gatsby site!")
     console.log(`Building with: ${pkgManager} run build ${gatsbyArgs}`)
     await exec.exec(`${pkgManager} run build`, [gatsbyArgs])
-    console.log("Finished buidling your site.")
+    console.log("Finished building your site.")
 
     const cnameExists = await ioUtil.exists("./CNAME")
     if (cnameExists) {


### PR DESCRIPTION
Implemented my proposed solution that fixes issue #5 

* Changed the build command so that it now runs the build script that's automatically generated by Gatsby. This makes the action work when using both yarn and npm as the package manager.

* Corrected a spelling mistake.