### PR TITLE
feat: enable to push to different repo & fix assignment to const issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ configuration options:
   [input][github-action-input].
   Defaults to `master`.
 
+- **deploy-repo**: The repository expected by GitHub to have the static files
+  needed for your site.
+  Provided as an [input][github-action-input].
+  Defaults to the same repository you place this action.
+
 - **gatsby-args**: Additional arguments that get passed to `gatsby build`. See the
   [Gatsby documentation][gatsby-build-docs] for a list of allowed options.
   Provided as an [input][github-action-input].

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "The branch expected by GitHub to have the static files needed for your site."
     required: false
     default: "master"
+  deploy-repo:
+    description: "The repo expected by GitHub to have the static files needed for your site."
+    required: false
+    default: ""
   gatsby-args:
     description: "Additional arguments that get passed to `gatsby build`."
     required: false

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ async function run() {
       return
     }
 
-    const deployBranch = core.getInput("deploy-branch")
+    let deployBranch = core.getInput("deploy-branch")
     if (!deployBranch) deployBranch = "master"
 
     if (github.context.ref === `refs/heads/${deployBranch}`) {
@@ -41,7 +41,8 @@ async function run() {
       console.log("Finished copying CNAME.")
     }
 
-    const repo = `${github.context.repo.owner}/${github.context.repo.repo}`
+    const deployRepo = core.getInput("deploy-repo")
+    const repo = `${github.context.repo.owner}/${deployRepo || github.context.repo.repo}`
     const repoURL = `https://${accessToken}@github.com/${repo}.git`
     console.log("Ready to deploy your new shiny site!")
     console.log(`Deploying to repo: ${repo} and branch: ${deployBranch}`)


### PR DESCRIPTION
1. Fix one minor error that happened to me when I didn't set the `deploy-branch` (will cause `##[error]Assignment to constant variable.` error)
2. I'm thinking it would be good if we can pass another variable to decide which repo we want to publish. Personally, I want to separate my blog src and the generated static site.