### PR TITLE
Added `skip-publish` argument for validating pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ configuration options:
   [Gatsby documentation][gatsby-build-docs] for a list of allowed options.
   Provided as an [input][github-action-input].
   Defaults to nothing.
+  
+- **skip-publish**: Allows skipping of the publish action - effectively performing
+  a test of the build process using the live configuration.
+  Provided as an [input][github-action-input]
+  Defaults to **false**
 
 ### Org or User Pages
 
@@ -97,6 +102,29 @@ jobs:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           deploy-branch: gh-pages
           gatsby-args: --prefix-paths
+```
+
+Provides build validation on `pull request` if required:
+
+```yml
+name: Gatsby Publish
+
+on:
+  pull-request:
+    branches:
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: gh-pages
+          gatsby-args: --prefix-paths
+          skip-publish: true
 ```
 
 ### CNAME

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Additional arguments that get passed to `gatsby build`."
     required: false
     default: ""
+  skip-publish:
+    description: "Skips publishing - performs build/test"
+    required: false
+    default: false
 runs:
   using: "node12"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -40,7 +40,16 @@ async function run() {
       await io.cp("./CNAME", "./public/CNAME", { force: true })
       console.log("Finished copying CNAME.")
     }
-
+    
+    // Skips publishing if required - used to test configuration with pull-requests/etc
+    let skipPublish = core.getInput("skip-publish")
+    if (undefined == skipPublish) skipPublish = false;
+    
+    if (skipPublish) {
+      console.log("Builing completed successfully - skipping publish"); 
+      return;
+    }
+        
     const deployRepo = core.getInput("deploy-repo")
     const repo = `${github.context.repo.owner}/${deployRepo || github.context.repo.repo}`
     const repoURL = `https://${accessToken}@github.com/${repo}.git`


### PR DESCRIPTION
Not sure if you're interested or not, but I added a `skip-publish: [false | true]` argument that allows validation of build (without publishing) of pull requests.  

When configured with:

```yml
name: validate-pull-request

on:
  pull_request:
    branches: 
      - gatsby

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v1
      - uses: kenjdavidson/gatsby-gh-pages-action@feature/build-only-config
        with:
          access-token: ${{ secrets.ACCESS_TOKEN }}
          skip-publish: true
```

the result will be:

```bash
info Done building in 37.636706557 sec
Finished building your site.
Builing completed successfully - skipping publish
```

Regardless, thanks for a great action.