### PR TITLE
Forward all gatsby-args to build command

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ async function run() {
     await exec.exec(`${pkgManager} install`)
     console.log("Finished installing dependencies.")
 
-    const gatsbyArgs = core.getInput("gatsby-args")
+    const gatsbyArgs = ["--", ...core.getInput("gatsby-args").split(" ")]
     console.log("Ready to build your Gatsby site!")
-    console.log(`Building with: ${pkgManager} run build ${gatsbyArgs}`)
-    await exec.exec(`${pkgManager} run build`, [gatsbyArgs])
+    console.log(`Building with: ${pkgManager} run build ${gatsbyArgs.join(" ")}`)
+    await exec.exec(`${pkgManager} run build`, gatsbyArgs)
     console.log("Finished building your site.")
 
     const cnameExists = await ioUtil.exists("./CNAME")


### PR DESCRIPTION
Should close issue  #13 

This prepends "--" to the build command so that gatsby-args are actually
used by the command called by `${pkgManager} run build`. Additionally,
the gatsby-arg input field is now space separated on input, so that each
flag is interpreted separately.

Though the original issue was solely about npm, as far as I can see the issue also relates to yarn. Because of that this change affects both package managers.

Hope this is useful! 😄 