### PR TITLE
Fix passing gatsby args to build command

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ async function run() {
 
     const gatsbyArgs = core.getInput("gatsby-args")
     console.log("Ready to build your Gatsby site!")
-    console.log(`Building with: ${pkgManager} run build ${gatsbyArgs}`)
-    await exec.exec(`${pkgManager} run build`, [gatsbyArgs])
+    console.log(`Building with: ${pkgManager} run build -- ${gatsbyArgs}`)
+    await exec.exec(`${pkgManager} run build --`, [gatsbyArgs])
     console.log("Finished building your site.")
 
     const cnameExists = await ioUtil.exists("./CNAME")


### PR DESCRIPTION
To pass parameters to the underlying npm script, you need to tell npm not to take anymore arguments with `--`

wrong:
```
npm run build --prefix-paths
```

right:
```
npm run build -- --prefix-paths
```