### PR TITLE
Updated to handle inputs being strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,9 @@ async function run() {
     
     // Skips publishing if required - used to test configuration with pull-requests/etc
     let skipPublish = core.getInput("skip-publish")
-    if (undefined == skipPublish) skipPublish = false;
+    if (undefined == skipPublish) skipPublish = 'false';
     
-    if (skipPublish) {
+    if ('true' === skipPublish) {
       console.log("Builing completed successfully - skipping publish"); 
       return;
     }


### PR DESCRIPTION
From pull request #16 I completely didn't realize that all inputs are treated as strings, which is why when adding:

    skip-publish: false

it was actually treated as 

    skip-pubilish: 'false'

which I just didn't even think to verify, since all the examples seem to show it as a boolean.  I've updated all the checks to use 'false' and 'true' where applicable.