### PR TITLE
UNTESTED: adding ternary check for gatsbyArgs being empty

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,7 @@ async function run(): Promise<void> {
 
     console.log('Ready to build your Gatsby site!')
     console.log(`Building with: ${pkgManager} run build ${gatsbyArgs.join(' ')}`)
-    await exec.exec(`${pkgManager} run build`, gatsbyArgs)
+    await exec.exec(`${pkgManager} run build`, gatsbyArgs.length > 0 ? gatsbyArgs : undefined)
     console.log('Finished building your site.')
 
     const cnameExists = await ioUtil.exists('./CNAME')


### PR DESCRIPTION
This PR is meant to try and resolve #29 however I was unable to determine how to test the action.

I'm assuming by using a ternary condition and passing `undefined` as the second argument to `exec.exec` when no `gatsby-args` is defined, no additional arguments will be passed to the run being executed which will result in `gatsby build` instead of `gatsby build ""`.

Please test this before merging.