### PR TITLE
Don't require a GitHub access token if in "skip publish" mode

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -59,15 +59,25 @@ beforeEach(() => {
 })
 
 describe('Gatsby Publish action', () => {
-  it('returns an error when no access token is given', async () => {
+  it('returns an error when no access token is given if skip-publish is not true', async () => {
     inputs['access-token'] = ''
+    inputs['skip-publish'] = ''
     const setFailedSpy = jest.spyOn(core, 'setFailed')
 
     await run()
 
     expect(setFailedSpy).toBeCalledWith(
-      'No personal access token found. Please provide one by setting the `access-token` input for this action.',
+      'No personal access token found. Please provide one by setting the `access-token` input for this action, or disable publishing by setting `skip-publish`.',
     )
+  })
+
+  it('does not return an error when no access token is given if skip-publish is true', async () => {
+    inputs['access-token'] = ''
+    inputs['skip-publish'] = 'true'
+
+    await run()
+
+    await expect(run()).resolves.not.toThrowError()
   })
 
   it('skips if deploy branch is the same as the current git head and the repo is the same', async () => {

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   access-token:
     description: "A personal access token needed to push your site after it has been built."
-    required: true
+    required: false
   deploy-branch:
     description: "The branch expected by GitHub to have the static files needed for your site."
     required: false

--- a/index.ts
+++ b/index.ts
@@ -8,10 +8,12 @@ const DEFAULT_DEPLOY_BRANCH = 'master'
 
 async function run(): Promise<void> {
   try {
+    const skipPublish = (core.getInput('skip-publish') || 'false').toUpperCase()
+
     const accessToken = core.getInput('access-token')
-    if (!accessToken) {
+    if (!accessToken && skipPublish !== 'TRUE') {
       core.setFailed(
-        'No personal access token found. Please provide one by setting the `access-token` input for this action.',
+        'No personal access token found. Please provide one by setting the `access-token` input for this action, or disable publishing by setting `skip-publish`.',
       )
       return
     }
@@ -51,7 +53,6 @@ async function run(): Promise<void> {
       console.log('Finished copying CNAME.')
     }
 
-    const skipPublish = (core.getInput('skip-publish') || 'false').toUpperCase()
     if (skipPublish === 'TRUE') {
       console.log('Building completed successfully - skipping publish')
       return


### PR DESCRIPTION
The `skip-publish` option allows you to build your Gatsby site but not publish it, "effectively performing a test of the build process using the live configuration". This is useful for CI purposes - i.e. checking your site builds, but not actually deploying.

However, at the moment, you have to provide an `access-token` when in "skip publish" mode, even though this is only used to publish.

This updates the action - including new tests - so that you are not required to specify the `access-token` option if you've asked to skip publishing.