### PR TITLE
allow pnpm to be used as package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ typings/
 
 # Optional eslint cache
 .eslintcache
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ configuration options:
   Provided as an [input][github-action-input].
   Defaults to `{actor}@users.noreply.github.com`, where `{actor}` is the GitHub username 
   of the action actor.
+
+- **pkg-manager**: Provide a custom package manager other than npm.
+  Provided as an [input][github-action-input].
   
 ### Org or User Pages
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: "The email adress under which the deploy commit is pushed to the deploy branch."
     required: false
     default: ""
+  pkg-manager:
+    description: "The package manager used to manage the project"
+    required: false
+    default: ""
 runs:
   using: "node12"
   main: "./dist/index.js"

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ async function run(): Promise<void> {
     }
 
     const workingDir = core.getInput('working-dir') || '.'
-    const pkgManager = await getPkgManager(workingDir)
+    const pkgManager = core.getInput('pkg-manager') || (await getPkgManager(workingDir))
     console.log(`Installing your site's dependencies using ${pkgManager}.`)
     await exec.exec(`${pkgManager} install`, [], {cwd: workingDir})
     console.log('Finished installing dependencies.')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gatsby-gh-pages-action",
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-gh-pages-action",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "GitHub Action to build and deploy your Gatsby site to GitHub Pages ❤️🎩",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
I am using pnpm instead of npm, and have modified this action to allow pnpm.

Also, I added a custom flag for package manager.