### PR TITLE
Bump node version to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - name: Checkout

--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node12"
+  using: "node16"
   main: "./dist/index.js"


### PR DESCRIPTION
Node 12 deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/